### PR TITLE
feat: pluggable per-instance logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.46",
       "license": "ISC",
       "dependencies": {
-        "@juzi/wechaty-puppet": "^1.0.134",
+        "@juzi/wechaty-puppet": "^1.0.148",
         "amqplib": "^0.7.1",
         "file-box": "npm:@juzi/file-box@^1.7.9",
         "onirii": "^1.3.6",
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@juzi/wechaty-puppet": {
-      "version": "1.0.134",
-      "resolved": "https://registry.npmjs.org/@juzi/wechaty-puppet/-/wechaty-puppet-1.0.134.tgz",
-      "integrity": "sha512-DrCPDQAVLUFEyZBM+snMn//on+TNKtmW/ckIZo40Pp1YJF4o4KNLd3qv8TqLPR9u+11BkeybKVGhzt0tB8Naew==",
+      "version": "1.0.148",
+      "resolved": "https://registry.npmjs.org/@juzi/wechaty-puppet/-/wechaty-puppet-1.0.148.tgz",
+      "integrity": "sha512-fkDeD7hcg3wKk51eb1Rz0xMtpk/u2stZUgZL2hC1mKVADMjJceIxSAEQR3hG98TpWxm+fLII90dqroPkXHFHiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -596,6 +596,171 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.9.3.tgz",
+      "integrity": "sha512-IaRq05ZLdtgF5h9CzlcgaNHyg4VXuiStnOFpfNEMuI5fm5afP2S0FHq8WdakUz5WppsbddTdplL+vpeApt/WCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.9.3.tgz",
+      "integrity": "sha512-Pbwe7xYprj/nEnZrNBvZfjnTxlBIcfApAGdz2EROhjpPj+FBqBa3wOogqbsuGGBdCphf8S+KPprL1z+oDWkmSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.9.3.tgz",
+      "integrity": "sha512-AQ5JZiwNGVV/2K2TVulg0mw/3LYfqpjZO6jDPtR2evNbk9Yt57YsVzS+3vHSlUBQDRV9/jqMuZYVU3P13xrk+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.9.3.tgz",
+      "integrity": "sha512-tzVH480RY6RbMl/QRgh5HK3zn1ZTFsThuxDGo6Iuk1MdwIbdFYUY034heWUTI4u3Db97ArKh0hNL0xhO3+PZdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.9.3.tgz",
+      "integrity": "sha512-ivXXBRDXDc9k4cdv10R21ccBmGebVOwKXT/UdH1PhxUn9m/h8erAWjz5pcELwjiMf27WokqPgaWVfaclDbgE+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.9.3.tgz",
+      "integrity": "sha512-ILsGMgfnOz1HwdDz+ZgEuomIwkP1PHT6maigZxaCIuC6OPEhKE8uYna22uU63XvYcLQvZYDzpR3ms47WQPuNEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.9.3.tgz",
+      "integrity": "sha512-e+XmltDVIHieUnNJHtspn6B+PCcFOMYXNJB1GqoCcyinkEIQNwC8KtWgMqUucUbEWJkPc35NHy9k8aCXRmw9Kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.9.3.tgz",
+      "integrity": "sha512-rqpzNfpAooSL4UfQnHhkW8aL+oyjqJniDP0qwZfGnjDoJSbtPysHg2LpcOBEdSnEH+uIZq6J96qf0ZFD8AGfXA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.9.3.tgz",
+      "integrity": "sha512-3YJJLQ5suIEHEKc1GHtqVq475guiyqisKSoUnoaRtxkDaW5g1yvPt9IoSLOe2mRs7+FFhGGU693RsBUSwOXSdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juzi/wechaty-puppet-rabbit",
-      "version": "1.0.46",
+      "version": "1.0.47",
       "license": "ISC",
       "dependencies": {
         "@juzi/wechaty-puppet": "^1.0.148",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@juzi/wechaty-puppet": "^1.0.134",
+    "@juzi/wechaty-puppet": "^1.0.148",
     "amqplib": "^0.7.1",
     "file-box": "npm:@juzi/file-box@^1.7.9",
     "onirii": "^1.3.6",

--- a/src/mq/mq-manager.ts
+++ b/src/mq/mq-manager.ts
@@ -58,7 +58,7 @@ export class MqManager extends EventEmitter {
     msg: ConsumeMessage | null,
     channel: AmqpChannelService | undefined,
   ) {
-    log.verbose(PRE, `consuming content: ${msg?.content.toString()}`)
+    this._log.verbose(PRE, `consuming content: ${msg?.content.toString()}`)
     const messageString = msg?.content.toString()
     if (!messageString) {
       await channel?.ackMessage(msg!)
@@ -70,7 +70,7 @@ export class MqManager extends EventEmitter {
       if (message.type === MqMessageType.command) {
         const waiter = this.MqCommandResponsePool.get(message.traceId)
         if (!waiter) {
-          log.warn(PRE, `MqCommandResponsePool Not Found ${message.traceId}`)
+          this._log.warn(PRE, `MqCommandResponsePool Not Found ${message.traceId}`)
           await channel?.ackMessage(msg!)
           return
         }
@@ -84,14 +84,14 @@ export class MqManager extends EventEmitter {
         this.handleEvent(message.eventType!, message.data)
       }
     } catch (e) {
-      log.error(PRE, `consumption() error: ${(e as Error).stack}`)
+      this._log.error(PRE, `consumption() error: ${(e as Error).stack}`)
     }
     await channel?.ackMessage(msg!)
   }
 
   public async init(option: {token: string, mqUri: string, exchangeBaseName: string}) {
     const { token, mqUri, exchangeBaseName } = option
-    log.info(PRE, `init(${token})`)
+    this._log.info(PRE, `init(${token})`)
     if (!this.puppetConnection) {
       if (!(token && mqUri)) {
         throw new Error(`init() need token and mqUri`)
@@ -114,7 +114,7 @@ export class MqManager extends EventEmitter {
   }
 
   public async destroy() {
-    log.info(PRE, `destroy(${this.token})`)
+    this._log.info(PRE, `destroy(${this.token})`)
     this.puppetConnection?.close()
     this.puppetConnection = undefined
     this.puppetChannel?.close()
@@ -122,14 +122,14 @@ export class MqManager extends EventEmitter {
   }
 
   private async initConnect() {
-    log.info(PRE, 'initConnect()')
+    this._log.info(PRE, 'initConnect()')
     await this.puppetConnection!.ready()
     await this.prepareConnectListener()
-    log.info(PRE, 'initConnect() connected mq service...')
+    this._log.info(PRE, 'initConnect() connected mq service...')
   }
 
   private async initChannel() {
-    log.info(PRE, 'initChannel()')
+    this._log.info(PRE, 'initChannel()')
     this.puppetChannel = await this.createChannelService(10)
     await this.prepareChannelListener()
     await this.prepareQueue(this.puppetChannel)
@@ -145,7 +145,7 @@ export class MqManager extends EventEmitter {
   }
 
   private async createChannelService(prefetch: number) {
-    log.info(PRE, 'Creating Channel ...')
+    this._log.info(PRE, 'Creating Channel ...')
     const channel = await this.puppetConnection?.createChannelService(false)
     if (channel) {
       await channel.setPrefetchCount(prefetch)
@@ -157,16 +157,16 @@ export class MqManager extends EventEmitter {
 
   private async prepareChannelListener() {
     this.puppetChannel?.addCloseListener(() => {
-      log.info(`puppetChannel on close listener`)
+      this._log.info(`puppetChannel on close listener`)
       void this.reconnectChannel()
     })
   }
 
   private async reconnectMainConnect(err: Error, type: LISTENER_TYPE) {
-    log.info(PRE, `reconnectMainConnect(${LISTENER_TYPE[type]})`)
+    this._log.info(PRE, `reconnectMainConnect(${LISTENER_TYPE[type]})`)
     this.connected = false
     if (this.restartingConnection) {
-      log.error(
+      this._log.error(
         PRE,
         `reconnectMainConnect(${LISTENER_TYPE[type]}) under processing...`,
       )
@@ -174,7 +174,7 @@ export class MqManager extends EventEmitter {
     }
 
     this.restartingConnection = true
-    log.error(
+    this._log.error(
       PRE,
       `reconnectMainConnect(${LISTENER_TYPE[type]}) MQ Service Connect Receive ${LISTENER_TYPE[type]} event: ${err}`,
     )
@@ -187,7 +187,7 @@ export class MqManager extends EventEmitter {
       })
       await this.startConsume()
     } catch (e) {
-      log.error(
+      this._log.error(
         PRE,
         `reconnectMainConnect(${
           LISTENER_TYPE[type] || type
@@ -198,25 +198,25 @@ export class MqManager extends EventEmitter {
       this.restartingConnection = false
     }
 
-    log.info(
+    this._log.info(
       PRE,
       `reconnectMainConnect(${LISTENER_TYPE[type]}) Reconnected MQ Service Done.`,
     )
   }
 
   public async reconnectChannel(): Promise<void> {
-    log.info(PRE, `reconnectChannel()`)
+    this._log.info(PRE, `reconnectChannel()`)
     if (this.restartingConnection) {
-      log.error(PRE, `reconnectChannel() restart connect under processing...`)
+      this._log.error(PRE, `reconnectChannel() restart connect under processing...`)
       return
     }
     if (this.restartingChannel) {
-      log.error(PRE, `reconnectChannel(}) restart channel under processing...`)
+      this._log.error(PRE, `reconnectChannel(}) restart channel under processing...`)
       return
     }
 
     this.restartingChannel = true
-    log.error(
+    this._log.error(
       PRE,
       `reconnectChannel(}) MQ Service Channel Connect Receive Close event.`,
     )
@@ -226,13 +226,13 @@ export class MqManager extends EventEmitter {
       this.puppetChannel = await this.createChannelService(10)
       await this.startConsumer()
     } catch (e) {
-      log.error(PRE, `reconnectChannel(}) Reconnect MQ Service Failed: ${e}`)
+      this._log.error(PRE, `reconnectChannel(}) Reconnect MQ Service Failed: ${e}`)
       return this.reconnectChannel()
     } finally {
       this.restartingChannel = false
     }
 
-    log.info(PRE, `reconnectChannel(}) Reconnected MQ Service Done.`)
+    this._log.info(PRE, `reconnectChannel(}) Reconnected MQ Service Done.`)
   }
 
   public async startConsume() {
@@ -240,21 +240,21 @@ export class MqManager extends EventEmitter {
       if (this.connected) {
         break
       }
-      log.warn(PRE, 'startConsume() MQ Server Connect Not Ready Yet')
+      this._log.warn(PRE, 'startConsume() MQ Server Connect Not Ready Yet')
       await sleep(5 * SECOND)
     }
     await this.stopConsume()
-    log.info(PRE, 'startConsume() Creating Consumer ...')
+    this._log.info(PRE, 'startConsume() Creating Consumer ...')
     await this.startConsumer()
   }
 
   public async stopConsume() {
-    log.info(PRE, 'stopConsume() Stopping Consumer ...')
+    this._log.info(PRE, 'stopConsume() Stopping Consumer ...')
     this.puppetChannel?.killConsume('puppetConsumer')
   }
 
   private async startConsumer() {
-    log.info(PRE, 'startConsumer()')
+    this._log.info(PRE, 'startConsumer()')
     this.puppetChannel?.consume(
       getTokenQueueName(this.token!),
       (msg) => void this.consumption(msg, this.puppetChannel),
@@ -268,7 +268,7 @@ export class MqManager extends EventEmitter {
     if (!message.traceId) {
       message.traceId = v4()
     }
-    log.verbose(PRE, `sendToServer(${JSON.stringify(message)})`)
+    this._log.verbose(PRE, `sendToServer(${JSON.stringify(message)})`)
     this.puppetChannel?.sendMessageToExchange(
       getServerExchangeName(this.exchangeBaseName!),
       'command',
@@ -293,7 +293,7 @@ export class MqManager extends EventEmitter {
       this.MqCommandResponsePool.set(message.traceId!, waiter)
     })
       .then((data) => {
-        log.verbose(PRE, `handleResponse(${JSON.stringify(data)})`)
+        this._log.verbose(PRE, `handleResponse(${JSON.stringify(data)})`)
         return data
       })
       .finally(() => {
@@ -318,13 +318,13 @@ export class MqManager extends EventEmitter {
   }
 
   private handleEvent(eventType: types.PuppetEventName, data: string) {
-    log.verbose(PRE, `handleEvent(${eventType}, ${data})`)
+    this._log.verbose(PRE, `handleEvent(${eventType}, ${data})`)
     switch (eventType) {
       case 'dong':
         this.emit('dong', JSON.parse(data))
         break
       case 'login':
-        log.info(PRE, `receive login event: ${data}`)
+        this._log.info(PRE, `receive login event: ${data}`)
         this.emit('login', JSON.parse(data))
         break
       case 'post-comment':
@@ -337,7 +337,7 @@ export class MqManager extends EventEmitter {
         this.emit('dirty', JSON.parse(data))
         break
       case 'logout':
-        log.info(PRE, `receive logout event: ${data}`)
+        this._log.info(PRE, `receive logout event: ${data}`)
         this.emit('logout', JSON.parse(data))
         break
       case 'ready':
@@ -386,13 +386,13 @@ export class MqManager extends EventEmitter {
         this.emit('wxxd-order', JSON.parse(data))
         break
       default:
-        log.warn(PRE, `handleEvent(${eventType}, ${data}) Not Support`)
+        this._log.warn(PRE, `handleEvent(${eventType}, ${data}) Not Support`)
     }
   }
 
   private async prepareQueue(channel: AmqpChannelService) {
     if (!channel) {
-      log.warn(PRE, `prepare() need channel`)
+      this._log.warn(PRE, `prepare() need channel`)
       return
     }
     await channel.initMetaConfigure({

--- a/src/mq/mq-manager.ts
+++ b/src/mq/mq-manager.ts
@@ -1,4 +1,5 @@
 import { log, types } from '@juzi/wechaty-puppet'
+import type { LoggerLike } from '@juzi/wechaty-puppet'
 import { ConsumeMessage } from 'amqplib'
 import Onirii from 'onirii'
 import { AmqpChannelService } from 'onirii/lib/service/amqp/amqp-channel-service'
@@ -40,10 +41,18 @@ export class MqManager extends EventEmitter {
   private exchangeBaseName: string | undefined
   private mqUri: string | undefined
 
+  private readonly _log: LoggerLike
+
   private MqCommandResponsePool = new Map<
     string,
     MqCommandResponseWaiter
   >()
+
+  constructor (logger?: LoggerLike) {
+    super()
+    this._log = logger ?? log
+    this._log.verbose(PRE, 'constructor()')
+  }
 
   private async consumption(
     msg: ConsumeMessage | null,

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -16,7 +16,7 @@ export type PuppetRabbitOptions = PUPPET.PuppetOptions & {
 const PRE = 'PuppetRabbit'
 
 class PuppetRabbit extends PUPPET.Puppet {
-  private readonly mqManager = new MqManager()
+  private readonly mqManager: MqManager
 
   private heartbeatTimer: NodeJS.Timer | undefined
 
@@ -25,6 +25,7 @@ class PuppetRabbit extends PUPPET.Puppet {
     if (!options.mqUri || !options.token) {
       throw new Error(`PuppetRabbit need mqUri and token`)
     }
+    this.mqManager = new MqManager(this.log)
     this.initEvents()
   }
 

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -1,6 +1,5 @@
 import * as PUPPET from '@juzi/wechaty-puppet'
 import { MqManager } from './mq/mq-manager.js'
-import { log } from '@juzi/wechaty-puppet'
 import { MqCommandType } from './model/mq.js'
 import { FileBox, FileBoxInterface, FileBoxType } from 'file-box'
 import { ContactListResponse } from './dto.js'
@@ -38,7 +37,7 @@ class PuppetRabbit extends PUPPET.Puppet {
   }
 
   override async onStart(): Promise<void> {
-    log.verbose(PRE, 'onStart()')
+    this.log.verbose(PRE, 'onStart()')
     await this.mqManager.init({
       token: this.options.token,
       mqUri: this.options.mqUri,
@@ -54,7 +53,7 @@ class PuppetRabbit extends PUPPET.Puppet {
   }
 
   override async onStop(): Promise<void> {
-    log.verbose(PRE, 'onStop()')
+    this.log.verbose(PRE, 'onStop()')
     await this.mqManager.destroy()
     this.stopHeartbeat()
   }
@@ -987,7 +986,7 @@ class PuppetRabbit extends PUPPET.Puppet {
       })
       .on('logout', (data: PUPPET.payloads.EventLogout) => {
         this.logout(data.data, true).catch(e =>
-          log.error('PuppetService', 'onGrpcStreamEvent() this.logout() rejection %s',
+          this.log.error('PuppetService', 'onGrpcStreamEvent() this.logout() rejection %s',
             (e as Error).message,
           )
         )


### PR DESCRIPTION
## Summary

Adopts the pluggable per-instance logger introduced in `@juzi/wechaty-puppet@1.0.148` (`PuppetOptions.logger` + readonly `Puppet.log: LoggerLike`), so that a Wechaty caller can pass in a logger with structured `botId` context and have every downstream line in `PuppetRabbit` + `MqManager` inherit it.

## Changes

- `PuppetRabbit`
  - Move `mqManager` field initialization into the constructor body so it runs after `super(options)` — required because `this.log` (from the new base class) is only populated after `super()`.
  - Pass `this.log` into `new MqManager(this.log)`.
  - Migrate 3 module-level `log.*` call sites to `this.log.*`.
  - Drop the now-unused module `log` import.
- `MqManager`
  - Add optional `LoggerLike` constructor arg with `?? log` brolog fallback (behaviour unchanged for direct callers that pass no logger).
  - Private `_log` field.
  - Migrate 32 instance-scope `log.*` call sites to `this._log.*`.
  - Keep the module-level `log` import solely as the constructor fallback.
- Bump `@juzi/wechaty-puppet` `^1.0.134` -> `^1.0.148`.
- Bump package version `1.0.46` -> `1.0.47`.

## Motivation

Multi-bot deployments where a single process runs several `PuppetRabbit` instances need their logs to be distinguishable by `botId`. The new base-class logger surface makes that possible without any per-call plumbing.

## Backward compatibility

Fully backward compatible. When no `logger` is supplied via `PuppetOptions`, `Puppet.log` falls back to brolog, and `MqManager` in turn falls back to brolog via its `?? log` default — identical to today's behaviour.

## Test plan

- [x] `npm run build` (tsc esm + cjs) passes locally
- [x] `tsc --noEmit` clean
- [ ] Downstream Wechaty bot smoke test: verify structured logger context propagates end-to-end