### PR TITLE
chore(deps): bump @juzi/wechaty-puppet to ^1.0.152

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.47",
       "license": "ISC",
       "dependencies": {
-        "@juzi/wechaty-puppet": "^1.0.148",
+        "@juzi/wechaty-puppet": "^1.0.152",
         "amqplib": "^0.7.1",
         "file-box": "npm:@juzi/file-box@^1.7.9",
         "onirii": "^1.3.6",
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@juzi/wechaty-puppet": {
-      "version": "1.0.148",
-      "resolved": "https://registry.npmjs.org/@juzi/wechaty-puppet/-/wechaty-puppet-1.0.148.tgz",
-      "integrity": "sha512-fkDeD7hcg3wKk51eb1Rz0xMtpk/u2stZUgZL2hC1mKVADMjJceIxSAEQR3hG98TpWxm+fLII90dqroPkXHFHiQ==",
+      "version": "1.0.152",
+      "resolved": "https://registry.npmjs.org/@juzi/wechaty-puppet/-/wechaty-puppet-1.0.152.tgz",
+      "integrity": "sha512-PqA32/Z+yy+Uzrfjd6hA/HMgF2a4qgDM1Le8cWiXFfHd9ELxYH71QoYLqW0x0gZCeKha50Lvf3disRoewqn9Hg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -643,9 +643,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -663,9 +660,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -683,9 +677,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -703,9 +694,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@juzi/wechaty-puppet": "^1.0.148",
+    "@juzi/wechaty-puppet": "^1.0.152",
     "amqplib": "^0.7.1",
     "file-box": "npm:@juzi/file-box@^1.7.9",
     "onirii": "^1.3.6",


### PR DESCRIPTION
## What
Bumps `@juzi/wechaty-puppet` `^1.0.148` → `^1.0.152` and refreshes `package-lock.json`.

## Why
`@juzi/wechaty-puppet` 1.0.152 adds three optional fields to `PremiumOnlineAppointmentCardPayload` (`commentContent` / `authorNickname` / `authorAvatar`) for the Xiaohongshu share-note-comment & note cards. This bump lets puppet-rabbit's type chain carry them.

## Compatibility
No code change. The `messagePremiumOnlineAppointmentCard` RPC (`src/model/puppet/message.ts`) types the response as `payloads.PremiumOnlineAppointmentCard` and passes the payload through as a typed DTO, so the new optional fields flow through automatically.

Verified locally: `npm install` (lockfile now resolves 1.0.152) + `npm run build` (tsc ESM + CJS) pass.

> Package version bump left to the publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)