### PR TITLE
ci: pin npm 11 in publish job (npm 12 skips lifecycle scripts, breaks pkg-jq)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -18,9 +18,12 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Install npm
-        run: curl -qL https://www.npmjs.com/install.sh | sh
+      # Pin npm 11: `install.sh` pulls the latest npm (12), and npm 12 skips
+      # dependency lifecycle scripts by default, so node-jq never fetches its
+      # jq binary and the pkg-jq calls below break with `spawn .../jq ENOENT`.
+      # npm 11 behaves like the runs that published successfully before 2026-07.
+      - name: Install npm 11
+        run: npm install -g npm@11
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
## Problem
The `Publish` job fails at **Set Publish Config**:
```
Error: spawn .../node_modules/node-jq/bin/jq ENOENT
  spawnargs: [ '-r', '.version', '.../package.json' ]
```
`scripts/package-publish-config-tag.sh` (and the `Is A Publish Branch` step) call `npx pkg-jq`, which wraps `node-jq`. `node-jq` downloads its `jq` binary in a postinstall script.

## Root cause
The `Install npm` step ran `curl -qL https://www.npmjs.com/install.sh | sh`, which installs the **latest** npm — now **npm 12**. npm 12 skips dependency lifecycle scripts by default, so node-jq's postinstall never runs, the `jq` binary is never fetched, and every `pkg-jq` call fails with `ENOENT`.

This is not related to any package change — a no-op push to `main` fails identically. The job last succeeded on 2026-07-01; it broke once runners started resolving npm 12.

## Fix
Pin npm 11 (`npm install -g npm@11`), which runs lifecycle scripts. This mirrors what `@juzi/wechaty-puppet` (#109 / #110) and `@juzi/wechaty` already do — both publish successfully today with this exact setup. No change to the publish scripts or pkg-jq usage is needed.

Once merged, the push to `main` re-triggers the job; `1.0.48` is not yet on npm, so it will publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)