### PR TITLE
feat: support Email message over MQ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.47",
+  "version": "1.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juzi/wechaty-puppet-rabbit",
-      "version": "1.0.47",
+      "version": "1.0.49",
       "license": "ISC",
       "dependencies": {
-        "@juzi/wechaty-puppet": "^1.0.152",
+        "@juzi/wechaty-puppet": "^1.0.153",
         "amqplib": "^0.7.1",
         "file-box": "npm:@juzi/file-box@^1.7.9",
         "onirii": "^1.3.6",
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@juzi/wechaty-puppet": {
-      "version": "1.0.152",
-      "resolved": "https://registry.npmjs.org/@juzi/wechaty-puppet/-/wechaty-puppet-1.0.152.tgz",
-      "integrity": "sha512-PqA32/Z+yy+Uzrfjd6hA/HMgF2a4qgDM1Le8cWiXFfHd9ELxYH71QoYLqW0x0gZCeKha50Lvf3disRoewqn9Hg==",
+      "version": "1.0.153",
+      "resolved": "https://registry.npmjs.org/@juzi/wechaty-puppet/-/wechaty-puppet-1.0.153.tgz",
+      "integrity": "sha512-BQH+uEu1jHo0/ao3SvGOCmCPzxfr1DBvcJylQZde2mTOayomb7rLrhzBnU8qeMIDKlXkoRfo8Mno7z/8KsRWCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "type": "module",
   "description": "",
   "main": "index.js",
@@ -25,7 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@juzi/wechaty-puppet": "^1.0.152",
+    "@juzi/wechaty-puppet": "^1.0.153",
     "amqplib": "^0.7.1",
     "file-box": "npm:@juzi/file-box@^1.7.9",
     "onirii": "^1.3.6",

--- a/src/model/mq.ts
+++ b/src/model/mq.ts
@@ -60,6 +60,7 @@ export enum MqCommandType {
   messagePayload = 'messagePayload',
   messageSendText = 'messageSendText',
   messageSendFile = 'messageSendFile',
+  messageSendEmail = 'messageSendEmail',
   messageSendMiniProgram = 'messageSendMiniProgram',
   messageSendUrl = 'messageSendUrl',
   messageSendLocation = 'messageSendLocation',
@@ -81,6 +82,7 @@ export enum MqCommandType {
 
   messageImage = 'messageImage',
   messageFile = 'messageFile',
+  messageEmail = 'messageEmail',
   messageUrl = 'messageUrl',
   messageLocation = 'messageLocation',
   messageContact = 'messageContact',
@@ -170,6 +172,7 @@ export type PuppetRequestTypeMap = {
   [MqCommandType.messagePayload]: PuppetDTO.MessagePayloadRequest
   [MqCommandType.messageSendText]: PuppetDTO.MessageSendTextRequest
   [MqCommandType.messageSendFile]: PuppetDTO.MessageSendFileRequest
+  [MqCommandType.messageSendEmail]: PuppetDTO.MessageSendEmailRequest
   [MqCommandType.messageSendMiniProgram]: PuppetDTO.MessageSendMiniProgramRequest
   [MqCommandType.messageSendUrl]: PuppetDTO.MessageSendUrlRequest
   [MqCommandType.messageSendLocation]: PuppetDTO.MessageSendLocationRequest
@@ -191,6 +194,7 @@ export type PuppetRequestTypeMap = {
 
   [MqCommandType.messageImage]: PuppetDTO.MessageImageRequest
   [MqCommandType.messageFile]: PuppetDTO.MessageFileRequest
+  [MqCommandType.messageEmail]: PuppetDTO.MessageEmailRequest
   [MqCommandType.messageUrl]: PuppetDTO.MessageUrlRequest
   [MqCommandType.messageLocation]: PuppetDTO.MessageLocationRequest
   [MqCommandType.messageContact]: PuppetDTO.MessageContactRequest
@@ -264,6 +268,7 @@ export type PuppetResponseTypeMap = {
   [MqCommandType.messagePayload]: PuppetDTO.MessagePayloadResponse
   [MqCommandType.messageSendText]: PuppetDTO.MessageSendTextResponse
   [MqCommandType.messageSendFile]: PuppetDTO.MessageSendFileResponse
+  [MqCommandType.messageSendEmail]: PuppetDTO.MessageSendEmailResponse
   [MqCommandType.messageSendMiniProgram]: PuppetDTO.MessageSendMiniProgramResponse
   [MqCommandType.messageSendUrl]: PuppetDTO.MessageSendUrlResponse
   [MqCommandType.messageSendLocation]: PuppetDTO.MessageSendLocationResponse
@@ -285,6 +290,7 @@ export type PuppetResponseTypeMap = {
 
   [MqCommandType.messageImage]: PuppetDTO.MessageImageResponse
   [MqCommandType.messageFile]: PuppetDTO.MessageFileResponse
+  [MqCommandType.messageEmail]: PuppetDTO.MessageEmailResponse
   [MqCommandType.messageUrl]: PuppetDTO.MessageUrlResponse
   [MqCommandType.messageLocation]: PuppetDTO.MessageLocationResponse
   [MqCommandType.messageContact]: PuppetDTO.MessageContactResponse

--- a/src/model/puppet/message.ts
+++ b/src/model/puppet/message.ts
@@ -25,10 +25,19 @@ export type MessageContactResponse = {
 
 export type MessageFileRequest = {
   messageId: string,
+  index?: number,
 }
 
 export type MessageFileResponse = {
   fileFilebox: string,
+}
+
+export type MessageEmailRequest = {
+  messageId: string,
+}
+
+export type MessageEmailResponse = {
+  email: payloads.Email,
 }
 
 export type MessageImageRequest = {
@@ -112,6 +121,15 @@ export type MessageSendFileRequest = {
 }
 
 export type MessageSendFileResponse = {
+  messageId?: string,
+}
+
+export type MessageSendEmailRequest = {
+  conversationId: string,
+  email: payloads.Email,
+}
+
+export type MessageSendEmailResponse = {
   messageId?: string,
 }
 

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -3,7 +3,7 @@ import { MqManager } from './mq/mq-manager.js'
 import { MqCommandType } from './model/mq.js'
 import { FileBox, FileBoxInterface, FileBoxType } from 'file-box'
 import { ContactListResponse } from './dto.js'
-import { stringifyFileBox } from './util/file.js'
+import { stringifyFileBox, toSerializableFileBox } from './util/file.js'
 import { PremiumOnlineAppointmentCardListRequest, PremiumOnlineAppointmentCardListResponse, PremiumOnlineAppointmentCardSendPayload, WxxdOrderDeliverySendRequest, WxxdOrderGenAfterSaleOrderRequest } from '@juzi/wechaty-puppet/dist/esm/src/schemas/mod.js'
 
 export type PuppetRabbitOptions = PUPPET.PuppetOptions & {
@@ -187,6 +187,38 @@ class PuppetRabbit extends PUPPET.Puppet {
       },
     })
     return response.messageId
+  }
+
+  override async messageSendEmail(conversationId: string, email: PUPPET.payloads.Email) {
+    const response = await this.mqManager.sendMqCommand({
+      commandType: MqCommandType.messageSendEmail,
+      data: {
+        conversationId,
+        email: await this.serializeEmailForSend(email),
+      },
+    })
+    return response.messageId
+  }
+
+  private async serializeEmailForSend(email: PUPPET.payloads.Email): Promise<PUPPET.payloads.Email> {
+    if (!email.attachments?.length) {
+      return email
+    }
+    const attachments = await Promise.all(
+      email.attachments.map(async (attachment) => {
+        if (!attachment.fileBox) {
+          return attachment
+        }
+        return {
+          ...attachment,
+          fileBox: await toSerializableFileBox(attachment.fileBox),
+        }
+      }),
+    )
+    return {
+      ...email,
+      attachments,
+    }
   }
 
   override async messageSendMiniProgram(conversationId: string, miniProgram: PUPPET.payloads.MiniProgram) {
@@ -394,14 +426,25 @@ class PuppetRabbit extends PUPPET.Puppet {
     return FileBox.fromJSON(response.imageFilebox)
   }
 
-  override async messageFile(messageId: string) {
+  override async messageFile(messageId: string, index?: number) {
     const response = await this.mqManager.sendMqCommand({
       commandType: MqCommandType.messageFile,
       data: {
         messageId,
+        index,
       },
     })
     return FileBox.fromJSON(response.fileFilebox)
+  }
+
+  override async messageEmail(messageId: string) {
+    const response = await this.mqManager.sendMqCommand({
+      commandType: MqCommandType.messageEmail,
+      data: {
+        messageId,
+      },
+    })
+    return response.email
   }
 
   override async messageUrl(messageId: string) {

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -1,4 +1,4 @@
-import { FileBoxInterface, FileBoxType } from "file-box"
+import { FileBox, FileBoxInterface, FileBoxType } from "file-box"
 
 export const stringifyFileBox = (file: FileBoxInterface) => {
   switch (file.type) {
@@ -8,5 +8,21 @@ export const stringifyFileBox = (file: FileBoxInterface) => {
       return JSON.stringify(file)
     default:
       throw new Error(`Unsupported filebox type: ${file.type}`)
+  }
+}
+
+/**
+ * Normalize a FileBox into a form that survives JSON transport over MQ.
+ * URL/Base64/QRCode boxes already serialize cleanly via toJSON; local and
+ * stream boxes carry no inline bytes, so they are materialized to base64 first.
+ */
+export const toSerializableFileBox = async (file: FileBoxInterface): Promise<FileBoxInterface> => {
+  switch (file.type) {
+    case FileBoxType.Base64:
+    case FileBoxType.Url:
+    case FileBoxType.QRCode:
+      return file
+    default:
+      return FileBox.fromBase64(await file.toBase64(), file.name)
   }
 }


### PR DESCRIPTION
## Summary

- `messageEmail` / `messageSendEmail` MQ commands + DTOs mirroring the messageUrl / messageSendUrl pattern
- `messageFile` forwards the new optional `index` (N-th email attachment)
- `toSerializableFileBox`: url/base64/qrcode FileBoxes pass through, local/stream materialized to base64 before the MQ JSON serialization

Depends on juzibot/wechaty-puppet#113 — build verified against the local link.

## Test plan

- [x] npm run build green locally (pre-existing file-box skew baseline errors unchanged: zero new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)