### PR TITLE
feat: support friendshipSearchHandle over MQ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@juzi/wechaty-puppet-rabbit",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "license": "ISC",
       "dependencies": {
         "@juzi/wechaty-puppet": "^1.0.153",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/src/model/mq.ts
+++ b/src/model/mq.ts
@@ -92,6 +92,7 @@ export enum MqCommandType {
   messageWxxdOrder = 'messageWxxdOrder',
 
   friendshipPayload = 'friendshipPayload',
+  friendshipSearchHandle = 'friendshipSearchHandle',
 
   postSearch = 'postSearch',
   postPayload = 'postPayload',
@@ -204,6 +205,7 @@ export type PuppetRequestTypeMap = {
   [MqCommandType.messageWxxdOrder]: PuppetDTO.MessageWxxdOrderRequest
 
   [MqCommandType.friendshipPayload]: PuppetDTO.FriendshipPayloadRequest
+  [MqCommandType.friendshipSearchHandle]: PuppetDTO.FriendshipSearchHandleRequest
 
   [MqCommandType.postSearch]: PuppetDTO.PostSearchRequest
   [MqCommandType.postPayload]: PuppetDTO.PostPayloadRequest
@@ -300,6 +302,7 @@ export type PuppetResponseTypeMap = {
   [MqCommandType.messageWxxdOrder]: PuppetDTO.MessageWxxdOrderResponse
   
   [MqCommandType.friendshipPayload]: PuppetDTO.FriendshipPayloadResponse
+  [MqCommandType.friendshipSearchHandle]: PuppetDTO.FriendshipSearchHandleResponse
 
   [MqCommandType.postSearch]: PuppetDTO.PostSearchResponse
   [MqCommandType.postPayload]: PuppetDTO.PostPayloadResponse

--- a/src/puppet.ts
+++ b/src/puppet.ts
@@ -535,6 +535,20 @@ class PuppetRabbit extends PUPPET.Puppet {
     return payload
   }
 
+  override async friendshipSearchHandle(handle: string, _type?: PUPPET.types.Contact): Promise<string | null> {
+    const response = await this.mqManager.sendMqCommand({
+      commandType: MqCommandType.friendshipSearchHandle,
+      data: {
+        handle,
+      },
+    })
+    return response.contactId ?? null
+  }
+
+  override async friendshipSearchPhone(_phone: string): Promise<string | null> {
+    throw new Error('friendshipSearchPhone is not supported by puppet-rabbit')
+  }
+
   // room
 
   override async roomAdd (roomId: string, contactId: string | string[], inviteOnly?: boolean, quoteIds?: string[]) {


### PR DESCRIPTION
## Summary

- Add `MqCommandType.friendshipSearchHandle` wired to the pre-existing `FriendshipSearchHandleRequest/Response` DTOs
- `PuppetRabbit.friendshipSearchHandle(handle)` sends the MQ command and resolves `contactId ?? null`
- `friendshipSearchPhone` fails fast (not supported) instead of a runtime TypeError
- Version bump 1.0.50

Downstream: email-call-center implements the command (search-by-address contact provisioning); xiaoju-bot-nested consumes via `Friendship.search({ handle })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)