### PR TITLE
fix: messageSendEmail 命令超时对齐 bot-nested 6 分钟发送信封

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-rabbit",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/src/mq/mq-manager.ts
+++ b/src/mq/mq-manager.ts
@@ -24,6 +24,13 @@ import { v4 } from 'uuid'
 
 const PRE = 'MqManager'
 
+const DEFAULT_COMMAND_TIMEOUT = 1 * MINUTE
+// 发邮件带大附件时 SMTP 上传可达数分钟，对齐 bot-nested 发送队列的 6 分钟信封；
+// MQ 消息自身 expiration 为 10 分钟，仍留有余量
+const COMMAND_TIMEOUT_OVERRIDES: Partial<Record<MqCommandType, number>> = {
+  [MqCommandType.messageSendEmail]: 6 * MINUTE,
+}
+
 enum LISTENER_TYPE {
   ERROR,
   CLOSE,
@@ -288,7 +295,7 @@ export class MqManager extends EventEmitter {
           reject(
             new Error(`async ${message.commandType} request timeout, traceId: ${message.traceId}`),
           )
-        }, 1 * MINUTE),
+        }, COMMAND_TIMEOUT_OVERRIDES[message.commandType] ?? DEFAULT_COMMAND_TIMEOUT),
       }
       this.MqCommandResponsePool.set(message.traceId!, waiter)
     })


### PR DESCRIPTION
## 背景

工作台经 email bot 发送带视频附件的邮件,SMTP 上传经跨境隧道实际耗时 121s,但 `MqManager.sendToServer` 对所有命令写死 1 分钟超时 → bot-nested 侧 60s 报「系统错误」,而邮件实际发送成功(成功回执因等待者已放弃被丢弃),用户重试会导致重复发信。

## 改动

- `COMMAND_TIMEOUT_OVERRIDES`:`messageSendEmail` 命令等待超时 1min → 6min,对齐 bot-nested 发送队列信封(`bot.mq-executor.service.ts` `timeout: 6 * MINUTE`);其余命令维持 1 分钟默认
- MQ 消息自身 expiration 为 10 分钟,仍留有余量

## 验证

- `npx tsc --noEmit` 通过